### PR TITLE
GITHUB workflows to build artifacts

### DIFF
--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -1,0 +1,58 @@
+name: Build unstable
+
+on: workflow_dispatch
+      
+jobs:
+  build:
+    name: BACCAble unstable
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1
+
+      - run: arm-none-eabi-gcc --version
+
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Compile BH
+        working-directory: ./firmware/ledsStripController
+        run: |
+          CFLAGS="-DRELEASE_FLAVOR=BH_FLAVOR -DBH_FLAVOR=1" make all
+          cp build/baccable-*.elf baccableBH_unstable.elf
+          
+      - name: Compile C1 Diesel
+        working-directory: ./firmware/ledsStripController
+        run: |
+          CFLAGS="-DRELEASE_FLAVOR=C1_FLAVOR -DC1_FLAVOR=1" make clean all
+          cp build/baccable-*.elf baccableC1diesel_unstable.elf
+
+      - name: Compile C1 Gasoline
+        working-directory: ./firmware/ledsStripController
+        run: |
+          CFLAGS="-DRELEASE_FLAVOR=C1_FLAVOR -DIS_GASOLINE -DC1_FLAVOR=1" make clean all
+          cp build/baccable-*.elf baccableC1gasoline_unstable.elf
+
+      - name: Compile C2
+        working-directory: ./firmware/ledsStripController
+        run: |
+          CFLAGS="-DRELEASE_FLAVOR=C2_FLAVOR -DC2_FLAVOR=1" make clean all
+          cp build/baccable-*.elf baccableC2_unstable.elf
+
+      - name: Compile CANable
+        working-directory: ./firmware/ledsStripController
+        run: |
+          CFLAGS="-DRELEASE_FLAVOR=CAN_FLAVOR -DCAN_FLAVOR=1" make clean all
+          cp build/baccable-*.elf baccableCANable_unstable.elf
+ 
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true
+          tag_name: continuous
+          files: |
+            ./firmware/ledsStripController/baccableBH_unstable.elf
+            ./firmware/ledsStripController/baccableC1diesel_unstable.elf
+            ./firmware/ledsStripController/baccableC1gasoline_unstable.elf
+            ./firmware/ledsStripController/baccableC2_unstable.elf
+            ./firmware/ledsStripController/baccableCANable_unstable.elf

--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -6,7 +6,6 @@ jobs:
   build:
     name: BACCAble unstable
     runs-on: ubuntu-latest
-
     steps:
       - uses: carlosperate/arm-none-eabi-gcc-action@v1
 
@@ -15,34 +14,43 @@ jobs:
       - name: Clone
         uses: actions/checkout@v3
 
+      - name: Set short git commit SHA
+        id: vars
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
+
+      - name: Confirm git commit SHA output
+        run: echo ${{ env.COMMIT_SHORT_SHA }}
+
       - name: Compile BH
         working-directory: ./firmware/ledsStripController
         run: |
-          CFLAGS="-DRELEASE_FLAVOR=BH_FLAVOR -DBH_FLAVOR=1" make all
+          CFLAGS='-DBUILD_VERSION=\"${{ env.COMMIT_SHORT_SHA }}\" -DRELEASE_FLAVOR=BH_FLAVOR -DBH_FLAVOR=1' make all
           cp build/baccable-*.elf baccableBH_unstable.elf
           
       - name: Compile C1 Diesel
         working-directory: ./firmware/ledsStripController
         run: |
-          CFLAGS="-DRELEASE_FLAVOR=C1_FLAVOR -DC1_FLAVOR=1" make clean all
+          CFLAGS='-DBUILD_VERSION=\"${{ env.COMMIT_SHORT_SHA }}\" -DRELEASE_FLAVOR=C1_FLAVOR -DC1_FLAVOR=1' make clean all
           cp build/baccable-*.elf baccableC1diesel_unstable.elf
 
       - name: Compile C1 Gasoline
         working-directory: ./firmware/ledsStripController
         run: |
-          CFLAGS="-DRELEASE_FLAVOR=C1_FLAVOR -DIS_GASOLINE -DC1_FLAVOR=1" make clean all
+          CFLAGS='-DBUILD_VERSION=\"${{ env.COMMIT_SHORT_SHA }}\" -DRELEASE_FLAVOR=C1_FLAVOR -DIS_GASOLINE -DC1_FLAVOR=1' make clean all
           cp build/baccable-*.elf baccableC1gasoline_unstable.elf
 
       - name: Compile C2
         working-directory: ./firmware/ledsStripController
         run: |
-          CFLAGS="-DRELEASE_FLAVOR=C2_FLAVOR -DC2_FLAVOR=1" make clean all
+          CFLAGS='-DBUILD_VERSION=\"${{ env.COMMIT_SHORT_SHA }}\" -DRELEASE_FLAVOR=C2_FLAVOR -DC2_FLAVOR=1' make clean all
           cp build/baccable-*.elf baccableC2_unstable.elf
 
       - name: Compile CANable
         working-directory: ./firmware/ledsStripController
         run: |
-          CFLAGS="-DRELEASE_FLAVOR=CAN_FLAVOR -DCAN_FLAVOR=1" make clean all
+          CFLAGS='-DBUILD_VERSION=\"${{ env.COMMIT_SHORT_SHA }}\" -DRELEASE_FLAVOR=CAN_FLAVOR -DCAN_FLAVOR=1' make clean all
           cp build/baccable-*.elf baccableCANable_unstable.elf
  
       - name: Release
@@ -50,6 +58,7 @@ jobs:
         with:
           prerelease: true
           tag_name: continuous
+          name: Unstable ${{ env.COMMIT_SHORT_SHA }}
           files: |
             ./firmware/ledsStripController/baccableBH_unstable.elf
             ./firmware/ledsStripController/baccableC1diesel_unstable.elf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,40 +21,41 @@ jobs:
       - name: Compile BH
         working-directory: ./firmware/ledsStripController
         run: |
-          CFLAGS="-DRELEASE_FLAVOR=BH_FLAVOR -DBH_FLAVOR=1" make all
-          cp build/baccable-*.elf baccableBH_stable_${{ github.ref_name }}.elf
+          CFLAGS='-DBUILD_VERSION=\"${{ github.ref_name }}\" -DRELEASE_FLAVOR=BH_FLAVOR -DBH_FLAVOR=1' make all
+          cp build/baccable-*.elf baccableBH_stable.elf
           
       - name: Compile C1 Diesel
         working-directory: ./firmware/ledsStripController
         run: |
-          CFLAGS="-DRELEASE_FLAVOR=C1_FLAVOR -DC1_FLAVOR=1" make clean all
-          cp build/baccable-*.elf baccableC1diesel_stable_${{ github.ref_name }}.elf
+          CFLAGS='-DBUILD_VERSION=\"${{ github.ref_name }}\" -DRELEASE_FLAVOR=C1_FLAVOR -DC1_FLAVOR=1' make clean all
+          cp build/baccable-*.elf baccableC1diesel_stable.elf
 
       - name: Compile C1 Gasoline
         working-directory: ./firmware/ledsStripController
         run: |
-          CFLAGS="-DRELEASE_FLAVOR=C1_FLAVOR -DIS_GASOLINE -DC1_FLAVOR=1" make clean all
-          cp build/baccable-*.elf baccableC1gasoline_stable_${{ github.ref_name }}.elf
+          CFLAGS='-DBUILD_VERSION=\"${{ github.ref_name }}\" -DRELEASE_FLAVOR=C1_FLAVOR -DIS_GASOLINE -DC1_FLAVOR=1' make clean all
+          cp build/baccable-*.elf baccableC1gasoline_stable.elf
 
       - name: Compile C2
         working-directory: ./firmware/ledsStripController
         run: |
-          CFLAGS="-DRELEASE_FLAVOR=C2_FLAVOR -DC2_FLAVOR=1" make clean all
-          cp build/baccable-*.elf baccableC2_stable_${{ github.ref_name }}.elf
+          CFLAGS='-DBUILD_VERSION=\"${{ github.ref_name }}\" -DRELEASE_FLAVOR=C2_FLAVOR -DC2_FLAVOR=1' make clean all
+          cp build/baccable-*.elf baccableC2_stable.elf
 
       - name: Compile CANable
         working-directory: ./firmware/ledsStripController
         run: |
-          CFLAGS="-DRELEASE_FLAVOR=CAN_FLAVOR -DCAN_FLAVOR=1" make clean all
-          cp build/baccable-*.elf baccableCANable_stable_${{ github.ref_name }}.elf
+          CFLAGS='-DBUILD_VERSION=\"${{ github.ref_name }}\" -DRELEASE_FLAVOR=CAN_FLAVOR -DCAN_FLAVOR=1' make clean all
+          cp build/baccable-*.elf baccableCANable_stable.elf
  
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           prerelease: false
+          name: Stable ${{ github.ref_name }}
           files: |
-            ./firmware/ledsStripController/baccableBH_stable_${{ github.ref_name }}.elf
-            ./firmware/ledsStripController/baccableC1diesel_stable_${{ github.ref_name }}.elf
-            ./firmware/ledsStripController/baccableC1gasoline_stable_${{ github.ref_name }}.elf
-            ./firmware/ledsStripController/baccableC2_stable_${{ github.ref_name }}.elf
-            ./firmware/ledsStripController/baccableCANable_stable_${{ github.ref_name }}.elf
+            ./firmware/ledsStripController/baccableBH_stable.elf
+            ./firmware/ledsStripController/baccableC1diesel_stable.elf
+            ./firmware/ledsStripController/baccableC1gasoline_stable.elf
+            ./firmware/ledsStripController/baccableC2_stable.elf
+            ./firmware/ledsStripController/baccableCANable_stable.elf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build stable 
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+      
+jobs:
+  build:
+    name: BACCAble stable
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1
+
+      - run: arm-none-eabi-gcc --version
+
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Compile BH
+        working-directory: ./firmware/ledsStripController
+        run: |
+          CFLAGS="-DRELEASE_FLAVOR=BH_FLAVOR -DBH_FLAVOR=1" make all
+          cp build/baccable-*.elf baccableBH_stable_${{ github.ref_name }}.elf
+          
+      - name: Compile C1 Diesel
+        working-directory: ./firmware/ledsStripController
+        run: |
+          CFLAGS="-DRELEASE_FLAVOR=C1_FLAVOR -DC1_FLAVOR=1" make clean all
+          cp build/baccable-*.elf baccableC1diesel_stable_${{ github.ref_name }}.elf
+
+      - name: Compile C1 Gasoline
+        working-directory: ./firmware/ledsStripController
+        run: |
+          CFLAGS="-DRELEASE_FLAVOR=C1_FLAVOR -DIS_GASOLINE -DC1_FLAVOR=1" make clean all
+          cp build/baccable-*.elf baccableC1gasoline_stable_${{ github.ref_name }}.elf
+
+      - name: Compile C2
+        working-directory: ./firmware/ledsStripController
+        run: |
+          CFLAGS="-DRELEASE_FLAVOR=C2_FLAVOR -DC2_FLAVOR=1" make clean all
+          cp build/baccable-*.elf baccableC2_stable_${{ github.ref_name }}.elf
+
+      - name: Compile CANable
+        working-directory: ./firmware/ledsStripController
+        run: |
+          CFLAGS="-DRELEASE_FLAVOR=CAN_FLAVOR -DCAN_FLAVOR=1" make clean all
+          cp build/baccable-*.elf baccableCANable_stable_${{ github.ref_name }}.elf
+ 
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: false
+          files: |
+            ./firmware/ledsStripController/baccableBH_stable_${{ github.ref_name }}.elf
+            ./firmware/ledsStripController/baccableC1diesel_stable_${{ github.ref_name }}.elf
+            ./firmware/ledsStripController/baccableC1gasoline_stable_${{ github.ref_name }}.elf
+            ./firmware/ledsStripController/baccableC2_stable_${{ github.ref_name }}.elf
+            ./firmware/ledsStripController/baccableCANable_stable_${{ github.ref_name }}.elf

--- a/firmware/ledsStripController/Core/Src/main.c
+++ b/firmware/ledsStripController/Core/Src/main.c
@@ -15,9 +15,17 @@
 	#include "lowConsume.h"
 	extern uint32_t lastReceivedCanMsgTime;
 #endif
-const char *FW_VERSION="BACCABLE V.2.5.4";  //this is used to store FW version, also shown on usb when used as slcan
 
+//this is used to store FW version, also shown on usb when used as slcan
+#ifndef BUILD_VERSION //compile time define with -D
+#define BUILD_VERSION "v2.5.4"
+#endif
+#define FW_PREFIX "BACCAble "
+#define _FW_VERSION FW_PREFIX BUILD_VERSION
+const char *FW_VERSION=_FW_VERSION;
 
+// force print
+#pragma message ("FW_VERSION: " _FW_VERSION)
 
 #if defined(UCAN_BOARD_LED_INVERSION)
 	const uint8_t led_light_on_bit=1;


### PR DESCRIPTION
due to github limitations actions won't be visible before merging this to master or main branch

### Build stable

create stable builds and runs on tag pushing; example:

```
git tag v2.5.4
git push origin --tags
```

then the workflow will start and create a release with title=tag; user can then review and add description 

### Build unstable

create unstable builds and must be run manually from `Actions -> Build unstable` then pick `Run workflow` (and optionally pick a different branch)

### Releases

https://github.com/anegrin/BACCAble/releases

here's an example result I will keep for a while

https://github.com/anegrin/BACCAble/releases/tag/v2.5.4 (alias for latest: https://github.com/anegrin/BACCAble/releases/latest )

build log: https://github.com/anegrin/BACCAble/actions/runs/14690776128 (see how we print `Core/Src/main.c:28:9: note: '#pragma message: FW_VERSION: BACCAble v2.5.4'`)

https://github.com/anegrin/BACCAble/releases/tag/continuous

build log: https://github.com/anegrin/BACCAble/actions/runs/14690824072 (see how we print `Core/Src/main.c:28:9: note: '#pragma message: FW_VERSION: BACCAble 30f564e'`)

here are github workflow limits for free plans https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits