### PR TITLE
FEATURE: debug mode

### DIFF
--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -62,10 +62,17 @@ jobs:
 
       - name: Compile CANable
         working-directory: ./firmware/ledsStripController
+        if: ${{ !contains(env.CFLAGS, '-DDEBUG_MODE')}}
         run: |
           CFLAGS='${{ env.CFLAGS }} -DBUILD_VERSION=\"${{ env.COMMIT_SHORT_SHA }}\" -DRELEASE_FLAVOR=CAN_FLAVOR -DCAN_FLAVOR=1' make clean all
           cp build/baccable-*.elf baccableCANable_unstable.elf
  
+      - name: CANable placeholder
+        working-directory: ./firmware/ledsStripController
+        if: ${{ contains(env.CFLAGS, '-DDEBUG_MODE')}}
+        run: |
+          echo "EMPTY" > baccableCANable_unstable.elf
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/firmware/ledsStripController/Core/Inc/compile_time_defines.h
+++ b/firmware/ledsStripController/Core/Inc/compile_time_defines.h
@@ -259,6 +259,10 @@
 	#endif
 
 	//note: with the following we avoid some combinations of defines.
+	#if (defined(DEBUG_MODE) && (defined(ACT_AS_CANABLE) || defined(LED_STRIP_CONTROLLER_ENABLED)))
+		#error "invalid combination of defines. If you want DEBUG_MODE, disable ACT_AS_CANABLE, LED_STRIP_CONTROLLER_ENABLED"
+	#endif
+
 	#if (defined(ACT_AS_CANABLE) && (defined(C1baccable) || defined(C2baccable) || defined(BHbaccable)))
 		#error "invalid combination of defines. If you want ACT_AS_CANABLE, disable C1, C2 and BH"
 	#endif

--- a/firmware/ledsStripController/Core/Inc/debug.h
+++ b/firmware/ledsStripController/Core/Inc/debug.h
@@ -1,0 +1,22 @@
+/*
+ * debug.h
+ *
+ *  Created on: May 13, 2025
+ *      Author: alessandro
+ */
+
+#ifndef INC_DEBUG_H_
+#define INC_DEBUG_H_
+#include "compile_time_defines.h"
+
+#ifdef DEBUG_MODE
+#include "usbd_cdc_if.h"
+#warning "enabling debug over USB for this build"
+#define LOGS(message) print_to_usb_(message)//simple string
+#define LOG(format, ...) printf_to_usb_(format, ##__VA_ARGS__)//formatted as sprintf
+#else
+#define LOG(...)//noop
+#define LOGS(message)//noop
+#endif
+
+#endif /* INC_DEBUG_H_ */

--- a/firmware/ledsStripController/Core/Inc/globalVariables.h
+++ b/firmware/ledsStripController/Core/Inc/globalVariables.h
@@ -33,7 +33,7 @@
 	#define LAST_PAGE_ADDRESS (FLASH_BANK1_END - FLASH_PAGE_SIZE +1) // 0x0801F800 //valid only for stm32F072 i suppose
 			//la flash inizia a 0x08000000  e finisce a 0x0801FFFF, -0x800 +1 di una pagina fa 0x0801F800
 
-#if defined(ACT_AS_CANABLE)
+#if defined(ACT_AS_CANABLE) ||  defined(DEBUG_MODE)
 	//#include "usbd_def.h"
 	#include "usb_device.h"
 	#include "string.h"

--- a/firmware/ledsStripController/Core/Inc/printf.h
+++ b/firmware/ledsStripController/Core/Inc/printf.h
@@ -35,6 +35,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#define PRINTF_INCLUDE_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/firmware/ledsStripController/Core/Inc/printf_config.h
+++ b/firmware/ledsStripController/Core/Inc/printf_config.h
@@ -1,0 +1,16 @@
+/*
+ * printf_config.h
+ *
+ *  Created on: May 14, 2025
+ *      Author: alessandro
+ */
+
+ #ifndef INC_PRINTF_CONFIG_H_
+ #define INC_PRINTF_CONFIG_H_
+
+ #define PRINTF_DISABLE_SUPPORT_EXPONENTIAL
+ #define PRINTF_DEFAULT_FLOAT_PRECISION 3
+ #define PRINTF_DISABLE_SUPPORT_LONG_LONG
+ #define PRINTF_DISABLE_SUPPORT_PTRDIFF_T
+
+ #endif /* INC_PRINTF_CONFIG_H_ */

--- a/firmware/ledsStripController/Core/Src/functions_Common.c
+++ b/firmware/ledsStripController/Core/Src/functions_Common.c
@@ -6,6 +6,7 @@
  */
 
 #include "functions_Common.h"
+#include "debug.h"
 
 void floatToStr(char* str, float num, uint8_t precision, uint8_t maxLen) {
     uint8_t i = 0;
@@ -169,6 +170,7 @@ void SystemClock_Config(void){
 
 
 void Error_Handler(void){
+  LOGS("System error\r\n");
   __disable_irq();
   while (1){}
 }

--- a/firmware/ledsStripController/Core/Src/main.c
+++ b/firmware/ledsStripController/Core/Src/main.c
@@ -12,7 +12,7 @@ int main(void){
 
 	uart_init();
 
-	#if defined(ACT_AS_CANABLE)
+	#if defined(ACT_AS_CANABLE) || defined(DEBUG_MODE)
 		MX_USB_DEVICE_Init();
 	#endif
 

--- a/firmware/ledsStripController/Core/Src/processingMessage0x000002FA.c
+++ b/firmware/ledsStripController/Core/Src/processingMessage0x000002FA.c
@@ -5,6 +5,7 @@
  *      Author: GauchoHP
  */
 
+#include "debug.h"
 #include "processingMessage0x000002FA.h"
 
 void processingMessage0x000002FA(){
@@ -490,6 +491,8 @@ void processingMessage0x000002FA(){
 						wheelPressedButtonID=0x90; //avoid returning here until button is not released
 
 						baccableDashboardMenuVisible=!baccableDashboardMenuVisible; //toggle visualizazion of the menu
+
+						LOG("Dashboard vis: %d\r\n", baccableDashboardMenuVisible);
 
 						if(!baccableDashboardMenuVisible){ //if menu needs to be hidden, print spaces to clear the string on dashboard
 							clearDashboardBaccableMenu();

--- a/firmware/ledsStripController/USB_DEVICE/App/usbd_cdc_if.c
+++ b/firmware/ledsStripController/USB_DEVICE/App/usbd_cdc_if.c
@@ -1,5 +1,4 @@
 #include "usbd_cdc_if.h"
-#include "main.h"
 /* Create buffer for reception and transmission           */
 /* It's up to user to redefine and/or remove those define */
 /** Received data over USB are stored in this buffer      */
@@ -274,3 +273,20 @@ uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len)
     USBD_CDC_SetTxBuffer(&hUsbDeviceFS, UserTxBufferFS, Len);
     return USBD_CDC_TransmitPacket(&hUsbDeviceFS);
 }
+
+#ifdef DEBUG_MODE
+uint8_t print_to_usb_(char* message)
+{
+    uint16_t msg_len = strlen(message);
+    return CDC_Transmit_FS((uint8_t*)message, msg_len < SLCAN_MTU ? msg_len : SLCAN_MTU);
+}
+
+uint8_t printf_to_usb_(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    int written = vsnprintf_((char*)slcan_str, SLCAN_MTU, format, args);
+    va_end(args);
+    return CDC_Transmit_FS(slcan_str, written < SLCAN_MTU ? (uint8_t) written : SLCAN_MTU);
+  }
+#endif

--- a/firmware/ledsStripController/USB_DEVICE/App/usbd_cdc_if.h
+++ b/firmware/ledsStripController/USB_DEVICE/App/usbd_cdc_if.h
@@ -6,6 +6,7 @@
 #endif
 
 #include "usbd_cdc.h"
+#include "main.h"
 //#include "usbd_conf.h"
 
 /* Define size for the receive and transmit buffer over CDC */
@@ -31,6 +32,10 @@ typedef struct _usbrx_buf_
 extern USBD_CDC_ItfTypeDef USBD_Interface_fops_FS;
 void cdc_process(void);
 uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len);
+#ifdef DEBUG_MODE
+uint8_t print_to_usb_(char* message);
+uint8_t printf_to_usb_(const char* format, ...);
+#endif
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
We can include `debug.h` when we need to log strings or formatted strings (super shortcut methods: LOGS/LOG)

By default both are NOOPs; **DO NOT** sprintf the string in your code as that comuptation will be done anyway, do use LOGS/LOG methods that won't even do the formatting if not enabled

When building we can use `-DDEBUG_MODE` and this will provide actual impl doing print/printf over USB

Can't be used with ACT_AS_CANABLE or LED_STRIP_CONTROLLER_ENABLED

If a board start with debug mode then it can be connected over usb as a serial port and we can use terminal apps like putty to check messages

I'm adding 2 samples:

LOGS -> log string -> `LOGS("System error\r\n");`
LOG -> log formatted -> `LOG("Dashboard vis: %d\r\n", baccableDashboardMenuVisible);`

I'm intentionally never adding `\r` or `\n` by default. user has to do so when needed.

Maximun length for messages is 30 chars (SLCAN_MTU)