### PR TITLE
dashboard items on steroids AKA user custom items

### DIFF
--- a/firmware/ledsStripController/Core/Inc/compile_time_defines.h
+++ b/firmware/ledsStripController/Core/Inc/compile_time_defines.h
@@ -199,6 +199,10 @@
 	#if defined(BHbaccable) //this works only on BH can bus (obd port pin 3 and pin 11)
 		#pragma message("Building BH BACCAble")
 
+		#ifndef DISPLAY_INFO_CODE//optional compile time define with -D, default: undefined
+			#define DISPLAY_INFO_CODE 0x09
+		#endif
+
 		#ifndef DISABLE_CLEAR_FAULTS_BH //optional compile time define with -D, default: undefined
 			#pragma message("Enabling CLEAR_FAULTS functionality")
 			#define CLEAR_FAULTS_ENABLED //if enabled the C1baccable menu will allow to reset faults thru BHbaccable too

--- a/firmware/ledsStripController/Core/Inc/user_config.h.sample
+++ b/firmware/ledsStripController/Core/Inc/user_config.h.sample
@@ -39,8 +39,19 @@
 	// #define DISABLE_DPF_REGEN_VISUAL_ALERT	// if uncommented it will disable visual alert in "DPF regeneration alert functionality"
 	// #define DISABLE_DPF_REGEN_SOUND_ALERT	// if uncommented it will disable sound alert in "DPF regeneration alert functionality"
 
-	// Demo on how to personalize dashboard items
+	// Demo on how to personalize dashboard items #define must be on a single line that's why we put \ at the end for readability
+	//
+	// X() params are:
+	//
 	// _itemUniqueId, _name, _reqId, _reqLen, _reqData, _replyId, _replyLen, _replyOffset, _replyValOffset, _replyScale, _replyScaleOffset, _replyDecimalDigits, _replyMeasurementUnit
+	//
+	// _itemUniqueId must be unique as the name suggests and it's up to the user (if not unique it won't compile)
+	//
+	// have a look at uds_params_array in globalVariables.c to get an idea of values you should put for you engine type
+	//
+	// This example show just 4 params; when building for Diesel then the Gasoline list of params will just have 1 element labeled as "Missing"
+	// and vice versa
+	//
 	// #define DASHBOARD_ITEMS \
 	//	X(IT_POWER, "Power: ", 0x11, 4, 0, 0xFB, 2, 0, -500, 0.000142378, 0, 1, "Hp") \
 	//	X(IT_TORQUE, "Torque: ", 0x12, 4, 0, 0xFB, 2, 0, 0, 1, -500, 0, "Nm") \

--- a/firmware/ledsStripController/Core/Inc/user_config.h.sample
+++ b/firmware/ledsStripController/Core/Inc/user_config.h.sample
@@ -39,6 +39,13 @@
 	// #define DISABLE_DPF_REGEN_VISUAL_ALERT	// if uncommented it will disable visual alert in "DPF regeneration alert functionality"
 	// #define DISABLE_DPF_REGEN_SOUND_ALERT	// if uncommented it will disable sound alert in "DPF regeneration alert functionality"
 
+	// Demo on how to personalize dashboard items
+	// _itemUniqueId, _name, _reqId, _reqLen, _reqData, _replyId, _replyLen, _replyOffset, _replyValOffset, _replyScale, _replyScaleOffset, _replyDecimalDigits, _replyMeasurementUnit
+	// #define DASHBOARD_ITEMS \
+	//	X(IT_POWER, "Power: ", 0x11, 4, 0, 0xFB, 2, 0, -500, 0.000142378, 0, 1, "Hp") \
+	//	X(IT_TORQUE, "Torque: ", 0x12, 4, 0, 0xFB, 2, 0, 0, 1, -500, 0, "Nm") \
+	//	X(IT_OIL_PRESS, "Oil press: ", 0x10, 4, 0, 0x04B2, 2, 0, 0, 0.1, 0, 1, "bar") \
+	//	X(IT_WATER_TEMP, "Water: ", 0x18DA10F1, 4, 0x03221003, 0x18DAF110, 2, 0, 0, 0.02, -40, 1, "\xB0" "C")
 
 
 
@@ -55,7 +62,7 @@
 
 
 	// The following defines are used, if uncommented, by BHbaccable board:
-
+	// #define DISPLAY_INFO_CODE 0x09			// if uncommented it will display preferred icon on dashboard (0x05=Aux, 0x06=left USB, 0x07=Right USB, 0x08=Center USB, 0x09=Bluetooth).
 	// #define DISABLE_CLEAR_FAULTS_BH 			// if uncommented it will disable "clear faults" functionality.
 
 

--- a/firmware/ledsStripController/Core/Src/globalVariables.c
+++ b/firmware/ledsStripController/Core/Src/globalVariables.c
@@ -123,11 +123,12 @@ const char *FW_VERSION=_FW_VERSION;
 			{0xD8,' ',' ','D','i','e','s','e','l',' ',' ',' ','P','a','r','a','m','s'},
 		};
 
-		uint8_t function_is_diesel_enabled=1; //stored in flash. defines if we use gasoline (0) or diesel (1) params
+	uint8_t function_is_diesel_enabled=1; //stored in flash. defines if we use gasoline (0) or diesel (1) params
+#ifndef DASHBOARD_ITEMS
 		uint8_t total_pages_in_dashboard_menu_diesel=38;
 		uint8_t total_pages_in_dashboard_menu_gasoline=37;
 		// uds_params_array[0] contais gasoline params, , uds_params_array[1] contains diesel params
-		const	uds_param_element uds_params_array[2][60]={
+		const uds_param_element uds_params_array[2][60]={
 										{
 												{.name={'P','O','W','E','R',':',' ',},								.reqId=0x11,	    .reqLen=4,	.reqData=SWAP_UINT32(0x00000000),   .replyId=0x000000FB,	.replyLen=2,	.replyOffset=0,	.replyValOffset=-500,	.replyScale=0.000142378,	.replyScaleOffset=0,	.replyDecimalDigits=1,	.replyMeasurementUnit={'C','V',}						}, //devo ricordare di moltiplicare il risultato per RPM
 												{.name={'T','O','R','Q','U','E',':',' ',},							.reqId=0x12,	    .reqLen=4,	.reqData=SWAP_UINT32(0x00000000),   .replyId=0x000000FB,	.replyLen=2,	.replyOffset=0,	.replyValOffset=0,		.replyScale=1,				.replyScaleOffset=-500,	.replyDecimalDigits=0,	.replyMeasurementUnit={'N','m',}						},
@@ -224,10 +225,41 @@ const char *FW_VERSION=_FW_VERSION;
 											{.name={'B','e','s','t','1','0','0','-','2','0','0',':',},			.reqId=0x1D,		.reqLen=4,	.reqData=SWAP_UINT32(0x00000000),	.replyId=0x00000000,	.replyLen=2,	.replyOffset=0, .replyValOffset=0,		.replyScale=1,				.replyScaleOffset=0,	.replyDecimalDigits=2,	.replyMeasurementUnit={'s', }							}, //statistic 0/100
 											{.name={'S','P','E','E','D',':',},									.reqId=0x18,		.reqLen=4,	.reqData=SWAP_UINT32(0x00000000),	.replyId=0x00000101,	.replyLen=2,	.replyOffset=0, .replyValOffset=0,		.replyScale=0.0625,			.replyScaleOffset=0,	.replyDecimalDigits=2,	.replyMeasurementUnit={'k','m','/','h', }				},
 
-										}
+										},
 
 		}; // initializes all the uds parameters request to send and reply to receive
-
+#else
+		typedef enum
+		{
+		#define X(id, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12) id,
+		    DASHBOARD_ITEMS
+		#undef X
+		        DASHBOARD_ITEMS_COUNT
+		} DashboardItemType;//not really needed but we need to count items
+#ifdef IS_DIESEL
+		uint8_t total_pages_in_dashboard_menu_diesel=DASHBOARD_ITEMS_COUNT;
+		uint8_t total_pages_in_dashboard_menu_gasoline=0;
+#else
+		uint8_t total_pages_in_dashboard_menu_diesel=0;
+		uint8_t total_pages_in_dashboard_menu_gasoline=DASHBOARD_ITEMS_COUNT;
+#endif
+		const uds_param_element uds_params_array[2][60]={
+#ifdef IS_DIESEL
+				{},
+#endif
+				{
+#define X(_, _name, _reqId, _reqLen, _reqData, _replyId, _replyLen, _replyOffset, _replyValOffset, _replyScale, _replyScaleOffset, _replyDecimalDigits, _replyMeasurementUnit) \
+	{.name=_name, .reqId=_reqId, .reqLen=_reqLen, .reqData=SWAP_UINT32(_reqData), .replyId=_replyId,	\
+	.replyLen=_replyLen, .replyOffset=_replyOffset,	.replyValOffset=_replyValOffset, .replyScale=_replyScale, .replyScaleOffset=_replyScaleOffset, \
+	.replyDecimalDigits=_replyDecimalDigits, .replyMeasurementUnit=_replyMeasurementUnit},
+DASHBOARD_ITEMS
+#undef X
+				},
+#ifdef IS_GASOLINE
+				{},
+#endif
+		};
+#endif
 	CAN_TxHeaderTypeDef uds_parameter_request_msg_header={.IDE=CAN_ID_EXT, .RTR = CAN_RTR_DATA, .ExtId=0x18DA10F1, .DLC=3};
 	uint8_t baccableDashboardMenuVisible=0;
 	uint8_t baccabledashboardMenuWasVisible=0; //tells us if menu was previously disabled (and then when motor will turn we want to show it again
@@ -369,7 +401,7 @@ const char *FW_VERSION=_FW_VERSION;
 	uint32_t lastSentTelematic_display_info_msg_Time=0;
 	uint8_t telematic_display_info_field_totalFrameNumber=(DASHBOARD_MESSAGE_MAX_LENGTH / 3) - 1; //it shall be a multiple of 3 reduced by 1 (example: 3x2-1=5)
 	uint8_t telematic_display_info_field_frameNumber=0; //current frame
-	uint8_t telematic_display_info_field_infoCode=0x09;
+	uint8_t telematic_display_info_field_infoCode=DISPLAY_INFO_CODE;
 	uint8_t paramsStringCharIndex=0; // next char to send index
 	CAN_TxHeaderTypeDef telematic_display_info_msg_header={.IDE=CAN_ID_STD, .RTR = CAN_RTR_DATA, .StdId=0x090, .DLC=8};
 	uint8_t telematic_display_info_msg_data[8];

--- a/firmware/ledsStripController/Core/Src/globalVariables.c
+++ b/firmware/ledsStripController/Core/Src/globalVariables.c
@@ -238,14 +238,14 @@ const char *FW_VERSION=_FW_VERSION;
 		} DashboardItemType;//not really needed but we need to count items
 #ifdef IS_DIESEL
 		uint8_t total_pages_in_dashboard_menu_diesel=DASHBOARD_ITEMS_COUNT;
-		uint8_t total_pages_in_dashboard_menu_gasoline=0;
+		uint8_t total_pages_in_dashboard_menu_gasoline=1;
 #else
-		uint8_t total_pages_in_dashboard_menu_diesel=0;
+		uint8_t total_pages_in_dashboard_menu_diesel=1;
 		uint8_t total_pages_in_dashboard_menu_gasoline=DASHBOARD_ITEMS_COUNT;
 #endif
 		const uds_param_element uds_params_array[2][60]={
 #ifdef IS_DIESEL
-				{},
+				{{.name="Missing", .reqId=0xFF, .reqLen=0, .reqData=SWAP_UINT32(0x00000000), .replyId=0xFF, .replyLen=0, .replyOffset=0, .replyValOffset=0, .replyScale=0, .replyScaleOffset=0,	.replyDecimalDigits=0, .replyMeasurementUnit=""}},
 #endif
 				{
 #define X(_, _name, _reqId, _reqLen, _reqData, _replyId, _replyLen, _replyOffset, _replyValOffset, _replyScale, _replyScaleOffset, _replyDecimalDigits, _replyMeasurementUnit) \
@@ -256,7 +256,7 @@ DASHBOARD_ITEMS
 #undef X
 				},
 #ifdef IS_GASOLINE
-				{},
+				{{.name="Missing", .reqId=0xFF, .reqLen=0, .reqData=SWAP_UINT32(0x00000000), .replyId=0xFF, .replyLen=0, .replyOffset=0, .replyValOffset=0, .replyScale=0, .replyScaleOffset=0,	.replyDecimalDigits=0, .replyMeasurementUnit=""}},
 #endif
 		};
 #endif


### PR DESCRIPTION
User can now configure it's own personalized list of params via user_config.h

It's up to the user to create a list for Gasoline or Diesel then the build process will control what code to generate

this is relying on c preprocessor so if we need to "debug" the generated code we can check intermediate generated code with a command like this:

<code>arm-none-eabi-gcc -DRELEASE_FLAVOR=C1_FLAVOR -DC1_FLAVOR=1 -DCORE_M0 -D HSI48_VALUE=48000000 -D HSE_VALUE=16000000 -DSTM32F072xB -IDrivers/CMSIS/Include -IDrivers/CMSIS/Device/ST/STM32F0xx/Include -IDrivers/STM32F0xx_HAL_Driver/Inc -ICore/Inc -IMiddlewares/ST/STM32_USB_Device_Library/Core/Inc -IMiddlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc -IUSB_DEVICE/Target -IUSB_DEVICE/App -mcpu=cortex-m0 -mthumb -Os -std=gnu11 -DUSE_HAL_DRIVER -DSTM32F072xB -static --specs=nano.specs -mthumb -mfloat-abi=soft -Wl,--start-group -lc -lm -Wl,--end-group -Wl,--gc-sections  -Wall -fstack-usage -fno-exceptions -ffunction-sections -fno-unwind-tables -fno-asynchronous-unwind-tables -fdata-sections -DINTERNAL_OSCILLATOR -DGIT_VERSION=\"test\" -DGIT_REMOTE=\"github.com:gaucho1978/BACCAble.git\" -DINCLUDE_USER_CONFIG_H -Os -E -o build/globalVariables.i Core/Src/globalVariables.c</code>

and then check `build/globalVariables.`

here's how the define is documented:

```c
	// Demo on how to personalize dashboard items #define must be on a single line that's why we put \ at the end for readability
	//
	// X() params are:
	//
	// _itemUniqueId, _name, _reqId, _reqLen, _reqData, _replyId, _replyLen, _replyOffset, _replyValOffset, _replyScale, _replyScaleOffset, _replyDecimalDigits, _replyMeasurementUnit
	//
	// _itemUniqueId must be unique as the name suggests and it's up to the user (if not unique it won't compile)
	//
	// have a look at uds_params_array in globalVariables.c to get an idea of values you should put for you engine type
	//
	// This example show just 4 params; when building for Diesel then the Gasoline list of params will just have 1 element labeled as "Missing"
	// and vice versa
	//
	// #define DASHBOARD_ITEMS \
	//	X(IT_POWER, "Power: ", 0x11, 4, 0, 0xFB, 2, 0, -500, 0.000142378, 0, 1, "Hp") \
	//	X(IT_TORQUE, "Torque: ", 0x12, 4, 0, 0xFB, 2, 0, 0, 1, -500, 0, "Nm") \
	//	X(IT_OIL_PRESS, "Oil press: ", 0x10, 4, 0, 0x04B2, 2, 0, 0, 0.1, 0, 1, "bar") \
	//	X(IT_WATER_TEMP, "Water: ", 0x18DA10F1, 4, 0x03221003, 0x18DAF110, 2, 0, 0, 0.02, -40, 1, "\xB0" "C")
```

`_itemUniqueId ` is not needed by dashaboard logic but we need them to count, we do generate am enum that's not used if not just to count

taking this change also to make DISPLAY_INFO_CODE configurable